### PR TITLE
Change `yamlresume.com` to `yamlresume.dev`

### DIFF
--- a/content/docs/compiler/schema/json.mdx
+++ b/content/docs/compiler/schema/json.mdx
@@ -8,7 +8,7 @@ YAMLResume provides an official [JSON Schema](https://json-schema.org) for
 validating resume data.
 
 The latest official JSON Schema is hosted at:
-[https://yamlresume.com/schema.json](https://yamlresume.com/schema.json).
+[https://yamlresume.dev/schema.json](https://yamlresume.dev/schema.json).
 However, if you want a cut-down version for your IDE/editor, you can also use
 the canary version
 [schema.json](https://github.com/yamlresume/yamlresume/blob/main/packages/core/src/schema/schema.json)
@@ -16,7 +16,7 @@ from our GitHub repo.
 
 Meanwhile, as YAMLResume evolves, the official JSON Schema will be updated
 constantly, hence we also provide all archived version of the JSON Schema at:
-`https://yamlresume.com/schemas/<version>/schema.json`.
+`https://yamlresume.dev/schemas/<version>/schema.json`.
 
 For now we have archived versions for:
 


### PR DESCRIPTION
The former domain doesn't exist, but it's incorrectly referenced twice in the documentation. The URLs work when the TLD is changed to `dev`.